### PR TITLE
Add a option to execute selected text with keybind

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,12 @@
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
                 "when": "editorTextFocus && editorLangId == sql"
+            },
+            {
+                "command": "mysql-scratchpad.executeSelectedText",
+                "key": "ctrl+enter",
+                "mac": "cmd+enter",
+                "when": "editorTextFocus && editorHasSelection && editorLangId == 'sql'"
             }
         ]
     },


### PR DESCRIPTION
Execute current statement is good, but sometimes we need to execute just part of a statement.