### PR TITLE
add args[] to mysqlConnect command

### DIFF
--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -23,12 +23,18 @@ export class ConnectionController{
                 err => this.handleConnectionError(err));
     }
 
-    public inputConnectionAndConnect():void{
+    public inputConnectionAndConnect(args: any[]):void{
         this._statusBarItem.text ='Connecting to MySQL server...';
         this._statusBarItem.show();
         OutputChannelController.showOutputChannel();
-        MySqlConnectionPrompt.getMysqlConnectionOptions()
-            .then(options => this.connect(options))
+        let connection_handle: Promise<Connection>;
+        if(Object.keys(args).length) {
+            connection_handle = this.connect(<ConnectionOptions> args);
+        } else {
+            connection_handle = MySqlConnectionPrompt.getMysqlConnectionOptions()
+                .then(options => this.connect(options));
+        }
+        connection_handle
             .then((connection:Connection) => this.onConnectionSuccess(), 
                 (error:QueryError) => this.onConnectionFailure(error));
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(requestController);
     context.subscriptions.push(connectionController);
     context.subscriptions.push(outputChannelController);
-    context.subscriptions.push(vscode.commands.registerCommand('mysql-scratchpad.mysqlConnect', () => connectionController.inputConnectionAndConnect()));
+    context.subscriptions.push(vscode.commands.registerCommand('mysql-scratchpad.mysqlConnect', (args: any[]) => connectionController.inputConnectionAndConnect(args)));
     context.subscriptions.push(vscode.commands.registerCommand('mysql-scratchpad.mysqlDisconnect', ()=> connectionController.closeConnection()));
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('mysql-scratchpad.executeCurrentStatement', editor => requestController.executeStatementUnderCursor(editor)));
     context.subscriptions.push(vscode.commands.registerCommand('mysql-scratchpad.openScratchpad', () => connectionController.openScratchpad()));


### PR DESCRIPTION
This PR adds the possibilty to add `"args": {...}` to `mysql-scratchpad.mysqlConnect`.

Concerning `MySQL: Connect`:
It is also possible to state the connection details directly when using a shortcut:
```
	{
		"key": "...",
		"command": "mysql-scratchpad.mysqlConnect",
		"args": {
			"host": "...",
			"user": "...",
			"password": "...",
			"port": "...",
			"database": "..."
		}
	}
```

Closes #9 